### PR TITLE
Add map location to UnetMobV2Class().load_from_checkpoint

### DIFF
--- a/maskay/library/unetmobv2.py
+++ b/maskay/library/unetmobv2.py
@@ -3,8 +3,14 @@ import pathlib
 import gdown
 import numpy as np
 
+try:
+    import torch
+except ImportError:
+    raise ImportError("Please install the following packages: torch.")
+
 from maskay.torch import Module
 from maskay.utils import get_models_path, softmax
+
 
 class UnetMobV2(Module):
     def __init__(self):
@@ -14,14 +20,13 @@ class UnetMobV2(Module):
     def forward(self, x):
         return self.model(x)
 
-    
     def inProcessing(self, tensor: np.ndarray):
         # If all the pixels are zero skip the run and outProcessing.
         if np.sum(tensor) == 0:
             shp = tensor.shape
             tensor = np.zeros(
                 (shp[0], 4, shp[2], shp[3])
-            ) # 4 is the number of the output classes
+            )  # 4 is the number of the output classes
             return [tensor]
         return tensor / 10000
 
@@ -47,9 +52,8 @@ def model_setup():
         nopkgs = ', '.join(is_external_package_installed)
         raise ImportError(
             f"Please install the following packages: {nopkgs}."
-        )    
-    
-    
+        )
+
     class UnetMobV2Class(pl.LightningModule):
         def __init__(self):
             super().__init__()
@@ -62,7 +66,7 @@ def model_setup():
 
         def forward(self, x):
             return self.model(x)
-        
+
     filename = pathlib.Path(get_models_path()) / "unetmobv2.ckpt"
     # Download the model if it doesn't exist
     if not filename.is_file():
@@ -70,6 +74,7 @@ def model_setup():
         url = "https://drive.google.com/uc?id=1o9LeVsXCeD2jmS-G8s7ZISfciaP9v-DU"
         gdown.download(url, filename.as_posix())
     # Load the model
-    model = UnetMobV2Class().load_from_checkpoint(filename.as_posix())
+    map_location = None if torch.cuda.is_available() else torch.device('cpu')
+    model = UnetMobV2Class().load_from_checkpoint(filename.as_posix(), map_location=map_location)
     model.eval()
     return model


### PR DESCRIPTION
Add map_location to UnetMobV2Class().load_from_checkpoint to avoid the following error:

```
CUDA device but torch.cuda.is_available() is False. If you are running on a CPU-only machine, please use torch.load with map_location=torch.device('cpu') to map your storages to the CPU.
```

This PR allows to run cloudsen12 in CPU environments only